### PR TITLE
Disable refresh image button after submit

### DIFF
--- a/HayRackController/pom.xml
+++ b/HayRackController/pom.xml
@@ -6,7 +6,7 @@
     <groupId>gift.goblin</groupId>
     <artifactId>HayRackController</artifactId>
 
-    <version>1.3.2</version>
+    <version>1.3.3-SNAPSHOT</version>
 
     <packaging>war</packaging>
 

--- a/HayRackController/src/main/resources/messages.properties
+++ b/HayRackController/src/main/resources/messages.properties
@@ -35,3 +35,4 @@ dashboard.cam_refresh=Refresh image automatically
 shutters.enter_manual_value=Enter value for manual movement...
 milliseconds=Milliseconds
 timetable.webcam=Webcam:
+webcam.choose_resolution=Choose Resolution

--- a/HayRackController/src/main/resources/messages_de.properties
+++ b/HayRackController/src/main/resources/messages_de.properties
@@ -31,3 +31,4 @@ dashboard.cam_refresh=Bild automatisch updaten
 shutters.enter_manual_value=Wert f\u00fcr manuelle Steuerung eingeben...
 milliseconds=Millisekunden
 timetable.webcam=Webcam:
+webcam.choose_resolution=Aufl\u00f6sung w\u00e4hlen

--- a/HayRackController/src/main/resources/messages_en.properties
+++ b/HayRackController/src/main/resources/messages_en.properties
@@ -31,3 +31,4 @@ dashboard.cam_refresh=Refresh image automatically
 shutters.enter_manual_value=Enter value for manual movement...
 milliseconds=Milliseconds
 timetable.webcam=Webcam:
+webcam.choose_resolution=Choose Resolution

--- a/HayRackController/src/main/resources/templates/dashboard.html
+++ b/HayRackController/src/main/resources/templates/dashboard.html
@@ -23,13 +23,13 @@
                         <i class="fas fa-home fa-4x"></i>
                     </a>
                 </li>
-                
+
                 <li class="nav-item">
                     <a class="nav-link" th:href="@{/shutter-control}">
                         <i class="fas fa-toolbox fa-4x"></i>
                     </a>
                 </li>
-                
+
                 <li class="nav-item">
                     <a class="nav-link" th:href="@{/timetable}">
                         <i class="fas fa-clipboard-list fa-4x"></i>
@@ -86,24 +86,54 @@
                             <div class="card-body mx-auto">
                                 <h5 class="card-title" th:text="${'Webcam ' + i}"></h5>
                                 <p class="card-text">
-                                    <button th:id="${'webcam-reload-' + i}" class="btn btn-primary btn-lg">
-                                        <i class="fa fa-sync-alt fa-4x"></i>
+                                    <button th:id="${'webcam-reload-' + i}" th:cam-id="${i}" class="webcam-reload-btn btn btn-primary btn-lg">
+                                        <i th:id="${'webcam-reload-icon-' + i}" class="fa fa-sync-alt fa-4x"></i>
                                     </button>
                                 </p>
                             </div>
-
-                            <script th:inline="javascript">
-
-                                $("#webcam-reload-" + [[${i}]]).on('click', function(event) {
-                                var d = new Date();
-                                $("#webcam-prev-" + [[${i}]]).attr("src", "/dashboard/webcam/webcam-" + [[${i}]] + "/sd?t=" + d.getTime());
-                                });
-                            </script>
                         </div> 
+                        <script th:inline="javascript">
+
+                            $('body').on('click', '.webcam-reload-btn', function (e) {
+                                var reloadButton = $(this);
+                                var dimension = "320x240";
+                                var camNumber = reloadButton.attr("cam-id");
+                                var postUrl = "/webcams/image";
+                                var imgTag = $("#webcam-prev-" + camNumber);
+                                var reloadIcon = $("#webcam-reload-icon-" + camNumber);
+                                
+                                reloadButton.prop('disabled', true);
+                                reloadIcon.addClass("fa-spin");
+                                console.log('calling getImage with:' + dimension + camNumber);
+
+                                $.ajax({
+                                    url: postUrl,
+                                    method: 'POST',
+                                    cache: false,
+                                    //dataType: 'json',
+                                    data: {
+                                        dimension: dimension,
+                                        camNumber: camNumber
+                                    }
+                                })
+                                        .done(function (data) {
+                                            console.log("Successful loading image from webcam");
+                                            document.getElementById("webcam-prev-" + camNumber).src = "data:image/png;base64," + data;
+                                        })
+                                        .fail(function (xhr, ajaxOptions, thrownError) {
+                                            console.log("Error while loading image from webcam");
+                                        })
+                                        .always(function () {
+                                            reloadIcon.removeClass("fa-spin");
+                                            reloadButton.prop('disabled', false);
+                                        });
+                            });
+                        </script>
+
                     </div>
                 </div>
             </div>
 
 
-        </body>
-        </html>
+    </body>
+</html>

--- a/HayRackController/src/main/resources/templates/webcam.html
+++ b/HayRackController/src/main/resources/templates/webcam.html
@@ -20,19 +20,19 @@
                         <i class="fas fa-home fa-4x"></i>
                     </a>
                 </li>
-                
+
                 <li class="nav-item">
                     <a class="nav-link" th:href="@{/shutter-control}">
                         <i class="fas fa-toolbox fa-4x"></i>
                     </a>
                 </li>
-                
+
                 <li class="nav-item">
                     <a class="nav-link" th:href="@{/timetable}">
                         <i class="fas fa-clipboard-list fa-4x"></i>
                     </a>
                 </li>
-                
+
                 <div th:each="i : ${#numbers.sequence( 1, webcam_count)}">
                     <div th:if="${i eq camNumber}">
                         <li class="nav-item active">
@@ -73,17 +73,17 @@
             <ul class="navbar-nav mx-auto">
                 <li class="nav-item">
                     <div class="dropdown">
-                        <button class="btn btn-secondary dropdown-toggle" type="button" id="dimensionBtn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Dropdown button
+                        <button class="btn btn-secondary dropdown-toggle" type="button" id="dimensionBtn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" th:text="#{webcam.choose_resolution}">
                         </button>
                         <div class="dropdown-menu" aria-labelledby="dimensionBtn">
-                            <a th:each="i : ${dimensions}" class="dropdown-item" th:id="${'dd-dimension-' + i}" th:text="${i}" th:value="${i}"></a>
+                            <a th:each="i : ${dimensions}" href="#" class="dropdown-item" th:id="${'dd-dimension-' + i}" th:text="${i}" th:value="${i}"></a>
                         </div>
                     </div>
                 </li>
                 <li class="nav-item">
                     <button disabled th:id="webcam-reload" class="btn btn-primary btn-lg">
-                        <i th:id="current-resolution" class="fa fa-sync-alt fa-lg"></i>
+                        <i th:id="reload-image-icon" class="fa fa-sync-alt fa-lg"></i>
+                        <a id="last-resolution"></a>
                     </button>
                 </li>
             </ul>
@@ -93,46 +93,50 @@
             <img id="camPreview" src="" />
         </p>
 
-        
+
         <script th:inline="javascript">
 
-                                $('body').on('click', '.dropdown-item', function (e) {
-                                    var t = $(this);
-                                    var dimension = t.attr("value");
-                                    var camNumber = $('#camNumber').text();
-                                    var postUrl = "/webcams/image";
-                                    
-                                    console.log('calling getImage with:' + dimension + camNumber);
-                                    
-                                    $.ajax({
-                                            url: postUrl,
-                                            method: 'POST',
-                                            cache: false,
-                                            //dataType: 'json',
-                                            data: {
-                                                dimension: dimension,
-                                                camNumber: camNumber
-                                            }
-                                })
-                                .done(function (data) {
-                                    console.log("Successful loading image from webcam");
-                                    document.getElementById("camPreview").src = "data:image/png;base64," + data;
-                                    $("#webcam-reload").prop('disabled', false);
-                                    $("#current-resolution").text(dimension);
-                                    
-                                })
-                                .fail(function (xhr, ajaxOptions, thrownError) {
-                                    console.log("Error while loading image from webcam");
-                                    $("#webcam-reload").prop('disabled', true);
-                                    $("#current-resolution").text("");
-                                });
-                                });
-                                
-                                $( "#current-resolution" ).click(function() {
-                                  var actResolution = $(this).text();
-                                  $( "a[value='" + actResolution + "']" ).click();
-                                });
-                            </script>
+            $('body').on('click', '.dropdown-item', function (e) {
+                var t = $(this);
+                var dimension = t.attr("value");
+                var camNumber = $('#camNumber').text();
+                var postUrl = "/webcams/image";
+                
+                $("#reload-image-icon").addClass("fa-spin");
+                $("#dimensionBtn").prop('disabled', true);
+                $("#webcam-reload").prop('disabled', true);
+                console.log('calling getImage with:' + dimension + camNumber);
+                
+                $.ajax({
+                    url: postUrl,
+                    method: 'POST',
+                    cache: false,
+                    //dataType: 'json',
+                    data: {
+                        dimension: dimension,
+                        camNumber: camNumber
+                    }
+                })
+                        .done(function (data) {
+                            console.log("Successful loading image from webcam");
+                            document.getElementById("camPreview").src = "data:image/png;base64," + data;
+                        })
+                        .fail(function (xhr, ajaxOptions, thrownError) {
+                            console.log("Error while loading image from webcam");
+                        })
+                        .always(function () {
+                            $("#webcam-reload").prop('disabled', false);
+                            $("#dimensionBtn").prop('disabled', false);
+                            $("#last-resolution").text(dimension);
+                            $("#reload-image-icon").removeClass("fa-spin");
+                        });
+            });
+
+            $("#webcam-reload").click(function () {
+                var resolution = $("#last-resolution").text();
+                $("a[value='" + resolution + "']").click();
+            });
+        </script>
 
     </body>
 </html>


### PR DESCRIPTION
Implemented jQuery methods, to deactivate the refresh-image button after you clicked it.
To prevent overflow of the webcam driver.